### PR TITLE
Correct detection of any sizing string

### DIFF
--- a/pyosolver.py
+++ b/pyosolver.py
@@ -260,12 +260,11 @@ def guess_type(key, data_string):
 		return True
 	if data_string == "False":
 		return False
-	print(key)
-	print(data_string)
 	if "Config" in key and "Size" in key:
 		if data_string.find(","):
 			try:
 				return [int(a) for a in data_string.split(",")]
+			#Case where sizings are expressed as allin 3x or 2e
 			except ValueError:
 				return data_string.split(",")
 		else:

--- a/pyosolver.py
+++ b/pyosolver.py
@@ -260,8 +260,19 @@ def guess_type(key, data_string):
 		return True
 	if data_string == "False":
 		return False
+	print(key)
+	print(data_string)
 	if "Config" in key and "Size" in key:
-		return [int(a) for a in data_string.split(",")]
+		if data_string.find(","):
+			try:
+				return [int(a) for a in data_string.split(",")]
+			except ValueError:
+				return data_string.split(",")
+		else:
+			try:
+				return [int(a) for a in data_string.split(" ")]
+			except ValueError:
+				return data_string.split(" ")
 	if "Range" in key:
 		return data_string.split(",")
 	if "Board" == key:


### PR DESCRIPTION
Different sizing strings can be used in PIO Config.Betsize such as 2e 3x a and comma separated sizings